### PR TITLE
Upgrade to Bookworm

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      IMAGE_VERSION: bullseye_rust_1.80.1-node_18.19.1
+      IMAGE_VERSION: bookworm_rust_1.80.1-node_18.19.1
 
     steps:
       - name: Checkout code

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:bullseye
+FROM buildpack-deps:bookworm
 
 # ----------------------
 # rust 1.80.1 via https://github.com/rust-lang/docker-rust/blob/3b6565cd3b0b7c9cb084f07461cb959f7cf77c16/1.80.1/bookworm/Dockerfile


### PR DESCRIPTION
Release an image built from Debian Bookworm. We might need to upgrade our main Dockerfile as we need the new `xmlsec` version. Even if somehow not, just releasing an image for bookworm can't hurt.

![image](https://github.com/user-attachments/assets/c855351f-2929-4c55-b075-dc824df5e307)
