### PR TITLE
chore: pin github actions to commit shas

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
       - name: Extract versions from Dockerfile
         id: versions
@@ -70,7 +70,7 @@ jobs:
           echo "  IMAGE_VERSION: $IMAGE_VERSION"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # v1.7.0
 
       - name: Login to GitHub Container Registry
         if: github.event_name == 'push'


### PR DESCRIPTION
Pins actions in .github/workflows to commit SHAs via pinact. Generated by multi-gitter.