### PR TITLE
chore: update Debian to trixie (13)

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        with:
+          persist-credentials: false
 
       - name: Extract versions from Dockerfile
         id: versions
@@ -33,11 +35,11 @@ jobs:
           echo "Image version: ${IMAGE_VERSION}"
 
       - name: Validate extracted versions
+        env:
+          RUST_VERSION: ${{ steps.versions.outputs.rust_version }}
+          NODE_VERSION: ${{ steps.versions.outputs.node_version }}
+          IMAGE_VERSION: ${{ steps.versions.outputs.image_version }}
         run: |
-          RUST_VERSION="${{ steps.versions.outputs.rust_version }}"
-          NODE_VERSION="${{ steps.versions.outputs.node_version }}"
-          IMAGE_VERSION="${{ steps.versions.outputs.image_version }}"
-
           # Check RUST_VERSION is not empty and matches version pattern
           if [ -z "$RUST_VERSION" ]; then
             echo "::error::Failed to extract RUST_VERSION from Dockerfile"
@@ -80,9 +82,9 @@ jobs:
         run: |
           # Build and tag the Docker image with the version
           docker buildx create --use
-          if [ "${{ github.event_name }}" = "push" ]; then
+          if [ "$EVENT_NAME" = "push" ]; then
             docker buildx build --push \
-              --tag ghcr.io/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]'):${{ steps.versions.outputs.image_version }} \
+              --tag "ghcr.io/$(echo "$REPOSITORY" | tr '[:upper:]' '[:lower:]'):$IMAGE_VERSION" \
               --platform linux/amd64,linux/arm64 .
           else
             docker buildx build \
@@ -91,3 +93,6 @@ jobs:
 
         env:
           DOCKER_CLI_ACI_AS_TEXT: "true"
+          EVENT_NAME: ${{ github.event_name }}
+          REPOSITORY: ${{ github.repository }}
+          IMAGE_VERSION: ${{ steps.versions.outputs.image_version }}

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -16,6 +16,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        debian_suite: [bookworm, trixie]
+
     steps:
       - name: Checkout code
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
@@ -24,10 +29,12 @@ jobs:
 
       - name: Extract versions from Dockerfile
         id: versions
+        env:
+          DEBIAN_SUITE: ${{ matrix.debian_suite }}
         run: |
           RUST_VERSION=$(grep -E '^[[:space:]]*RUST_VERSION=' Dockerfile | head -1 | cut -d'=' -f2)
           NODE_VERSION=$(grep -E '^ENV NODE_VERSION=' Dockerfile | head -1 | cut -d'=' -f2)
-          IMAGE_VERSION="bookworm_rust_${RUST_VERSION}-node_${NODE_VERSION}"
+          IMAGE_VERSION="${DEBIAN_SUITE}_rust_${RUST_VERSION}-node_${NODE_VERSION}"
           echo "rust_version=${RUST_VERSION}" >> $GITHUB_OUTPUT
           echo "node_version=${NODE_VERSION}" >> $GITHUB_OUTPUT
           echo "image_version=${IMAGE_VERSION}" >> $GITHUB_OUTPUT
@@ -61,7 +68,7 @@ jobs:
           fi
 
           # Validate final image version format
-          if ! echo "$IMAGE_VERSION" | grep -qE '^bookworm_rust_[0-9]+\.[0-9]+-node_[0-9]+\.[0-9]+\.[0-9]+$'; then
+          if ! echo "$IMAGE_VERSION" | grep -qE '^(bookworm|trixie)_rust_[0-9]+\.[0-9]+-node_[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "::error::IMAGE_VERSION '$IMAGE_VERSION' does not match expected format"
             exit 1
           fi
@@ -84,10 +91,12 @@ jobs:
           docker buildx create --use
           if [ "$EVENT_NAME" = "push" ]; then
             docker buildx build --push \
+              --build-arg "DEBIAN_SUITE=$DEBIAN_SUITE" \
               --tag "ghcr.io/$(echo "$REPOSITORY" | tr '[:upper:]' '[:lower:]'):$IMAGE_VERSION" \
               --platform linux/amd64,linux/arm64 .
           else
             docker buildx build \
+              --build-arg "DEBIAN_SUITE=$DEBIAN_SUITE" \
               --platform linux/amd64,linux/arm64 .
           fi
 
@@ -96,3 +105,4 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           REPOSITORY: ${{ github.repository }}
           IMAGE_VERSION: ${{ steps.versions.outputs.image_version }}
+          DEBIAN_SUITE: ${{ matrix.debian_suite }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:bookworm
+FROM buildpack-deps:trixie
 
 # ----------------------
 # rust 1.91 via https://github.com/rust-lang/docker-rust/blob/3b6565cd3b0b7c9cb084f07461cb959f7cf77c16/1.80.1/bookworm/Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM buildpack-deps:trixie
+# Debian suite to build against (e.g. bookworm or trixie)
+ARG DEBIAN_SUITE=trixie
+FROM buildpack-deps:${DEBIAN_SUITE}
 
 # ----------------------
 # rust 1.91 via https://github.com/rust-lang/docker-rust/blob/3b6565cd3b0b7c9cb084f07461cb959f7cf77c16/1.80.1/bookworm/Dockerfile


### PR DESCRIPTION
Updating Debian to [trixie](https://www.debian.org/releases/trixie), which has full support until August 9th, 2028 and two years of Long Term Support (LTS), until June 30th, 2030.

Also fixed CI issues raised by Semgrep (and then `zizmor` locally).

